### PR TITLE
Added a public get_timescale() to SidxContents.

### DIFF
--- a/library/dash/sidx_contents.h
+++ b/library/dash/sidx_contents.h
@@ -45,6 +45,9 @@ class SidxContents : public FullBoxContents {
   const std::vector<DashToHlsSegment>& get_locations() const {
     return locations_;
   }
+  const uint32_t get_timescale() const {
+    return timescale_;
+  }
   virtual std::string PrettyPrint(std::string indent) const;
   virtual std::string BoxName() const {return "SegmentIndex";}
 


### PR DESCRIPTION
This is needed for using the timescale value from the sidx box, overriding the value from mvhd.