### PR TITLE
according to iso 14496-12:2012, for box type 'mdhd', version 1, size …

### DIFF
--- a/library/dash/mdhd_contents.cc
+++ b/library/dash/mdhd_contents.cc
@@ -72,8 +72,8 @@ size_t MdhdContents::Parse(const uint8_t* buffer, size_t length) {
     ptr += sizeof(uint64_t);
     modification_time_ = ntohllFromBuffer(ptr);
     ptr += sizeof(uint64_t);
-    timescale_ = ntohllFromBuffer(ptr);
-    ptr += sizeof(uint64_t);
+    timescale_ = ntohlFromBuffer(ptr);
+    ptr += sizeof(uint32_t);
     duration_ = ntohllFromBuffer(ptr);
     ptr += sizeof(uint64_t);
   }


### PR DESCRIPTION
…of timescale is unsigned int(32)
